### PR TITLE
fix: doc.parent can be undefined

### DIFF
--- a/src/utilities/generateTreeList.ts
+++ b/src/utilities/generateTreeList.ts
@@ -11,7 +11,7 @@ export function generateTreeList(docs?: PaginatedDocs["docs"]) {
   const rootDocs = [];
 
   docs.forEach(doc => {
-    if (doc.parent === null) {
+    if (typeof doc.parent === 'undefined' || doc.parent === null) {
       rootDocs.push(docsById[doc.id]);
     } else {
       docsById[doc.parent].children.push(docsById[doc.id]);


### PR DESCRIPTION
On payloadcms 3.1.0 using MongoDB parent field is not being created when null. This is causing 500 error and this small commit should fix it.