### PR TITLE
fix: Use React.Suspense on col.renderedCells

### DIFF
--- a/src/TreeListView/Table/Table.tsx
+++ b/src/TreeListView/Table/Table.tsx
@@ -82,8 +82,8 @@ export const Table: React.FC<Props> = ({ columns, data, enableRowSelections, isC
                     <div aria-hidden="true" role="cell" />
                   )}
                   {activeColumns.map((col, colIndex) => (
-                    <Suspense fallback={<span />}>
-                      <div className={`cell-${col.accessor}`} key={colIndex} role="cell">
+                    <Suspense key={colIndex} fallback={<span />}>
+                      <div className={`cell-${col.accessor}`} role="cell">
                         {col.renderedCells[row.originalIndex]}
                       </div>
                     </Suspense>

--- a/src/TreeListView/Table/Table.tsx
+++ b/src/TreeListView/Table/Table.tsx
@@ -3,7 +3,7 @@ import type { PaginatedDocs } from "payload";
 
 import { ChevronIcon, SelectAll, SelectRow } from "@payloadcms/ui";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import React, { useMemo, useState } from "react";
+import React, { Suspense, useMemo, useState } from "react";
 
 import { generateTreeList } from "./generateTreeList.js";
 
@@ -81,14 +81,13 @@ export const Table: React.FC<Props> = ({ columns, data, enableRowSelections, isC
                   ) : (
                     <div aria-hidden="true" role="cell" />
                   )}
-                  {activeColumns.map((col, colIndex) => {
-                    const Component = col.renderedCells[row.originalIndex]?.type || "span";
-                    return (
+                  {activeColumns.map((col, colIndex) => (
+                    <Suspense fallback={<span />}>
                       <div className={`cell-${col.accessor}`} key={colIndex} role="cell">
-                        <Component {...col.renderedCells[row.originalIndex].props} />
+                        {col.renderedCells[row.originalIndex]}
                       </div>
-                    );
-                  })}
+                    </Suspense>
+                  ))}
                   <div className="cell-trigger" role="cell">
                     <Collapsible.Trigger asChild>
                       {hasChildren && (


### PR DESCRIPTION
<img width="1807" height="904" alt="20251005_144654" src="https://github.com/user-attachments/assets/3def88df-0a63-478b-a281-9a9705761a85" />

Hi there, I'm using payloadcms 3.58.0 and find out this plugin doesn't render the value on the list. 

Issue:
The table columns (col.renderedCells) were returning React.lazy elements.

Resolution: 
Updated the rendering logic to render the cell element directly inside a React.Suspense boundary. This ensures that lazy-loaded components are properly resolved and displayed, while providing a fallback (<span />) during loading.